### PR TITLE
react icon error removed

### DIFF
--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { FaPlay } from "react-icond/fa";
+import { FaPlay } from "react-icons/fa";
 
 interface ListItemProps {
   image: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4467,7 +4467,6 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.4.tgz",
       "integrity": "sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the import path for the FaPlay icon from 'react-icond/fa' to 'react-icons/fa'.