### PR TITLE
createContext Error Solved

### DIFF
--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -3,7 +3,9 @@ import {
     useSessionContext, 
     useUser as useSupaUser 
 } from "@supabase/auth-helpers-react";
-import { createContext, useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import { createContext } from "react";
+
 
 import { Subscription, UserDetails } from "@/types";
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Resolve an issue where `createContext` was throwing an error.